### PR TITLE
Exclude untimed events from hourly timeline grid and ignore Xcode build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
 node_modules/
+
+# Keep this repository focused on web app source files.
+# Ignore native macOS/Xcode project workspace and build artifacts.
+TimeScapeMac/
+.build/
+
+# macOS/Xcode generated artifacts
+.DS_Store
+DerivedData/
+*.dSYM/
+*.xcuserstate
+*.xcuserdatad/
+*.xcworkspace/
+*.xcodeproj/xcuserdata/

--- a/daily-view.js
+++ b/daily-view.js
@@ -215,9 +215,9 @@
     var evs = expandEvents(dateStr, dateStr) ?? loadEvents().filter(function(e) { return e && e.date === dateStr; });
     evs.forEach(function(e) {
       var s = toMinutes(e.startTime, null);
+      if (s === null) return; // Untimed/all-day events belong in all-day lanes, not the hourly grid.
       var eMin = toMinutes(e.endTime, null);
       var hasTimes = s !== null;
-      if (s === null) s = 9 * 60; // default 9am if no time
       if (eMin === null) eMin = s + 60;
       if (eMin <= s) eMin += 1440;
       var domain = getDomainLocal(e);

--- a/desktop-calendar-features.js
+++ b/desktop-calendar-features.js
@@ -1646,9 +1646,9 @@
 
     evts.forEach(function (e) {
       var s = toMin(e.time);
+      if (s === null) return; /* keep all-day/untimed events out of timeline; shown in untimed section */
       var en = toMin(e.endTime);
       var hasTimes = s !== null;
-      if (s === null) s = 9 * 60;
       if (en === null) en = s + 60;
       if (en <= s) en = s + 60;
       items.push({ kind: 'event', title: e.title || 'Event', emoji: e.emoji || '📌', startMin: s, endMin: en, hasTimes: hasTimes, color: dcs[e.domain || 'personal'] || '#4a90e2', eventId: e.id, repeat: e.repeat || 'none', occurrenceDate: e.occurrenceDate || '' });


### PR DESCRIPTION
Skip events with no start time in the hourly timeline grid, ensuring that untimed and all-day events are displayed in the appropriate section. Additionally, update the .gitignore file to exclude native macOS/Xcode project workspace and build artifacts.